### PR TITLE
Don't attempt to unset commandMap field modifiers field

### DIFF
--- a/src/main/java/org/inventivetalent/pluginannotations/AccessUtil.java
+++ b/src/main/java/org/inventivetalent/pluginannotations/AccessUtil.java
@@ -14,10 +14,14 @@ public class AccessUtil {
 	/**
 	 * Set a specified Field accessible
 	 *
-	 * @param f Field set accessible
+	 * @param field Field to set accessible
+	 * @param readOnly Whether removing final modifier should not be attempted
 	 */
-	public static Field setAccessible(Field field) throws ReflectiveOperationException {
+	public static Field setAccessible(Field field, boolean readOnly) throws ReflectiveOperationException {
 		field.setAccessible(true);
+		if (readOnly) {
+			return field;
+		}
 		int newModifiers = field.getModifiers() & ~Modifier.FINAL;
 		if (modifiersVarHandle != null) {
 			((VarHandle) modifiersVarHandle).set(field, newModifiers);
@@ -25,6 +29,15 @@ public class AccessUtil {
 			modifiersField.setInt(field, newModifiers);
 		}
 		return field;
+	}
+
+	/**
+	 * Set a specified Field accessible
+	 *
+	 * @param field Field to set accessible
+	 */
+	public static Field setAccessible(Field field) throws ReflectiveOperationException {
+		return setAccessible(field, false);
 	}
 
 	/**

--- a/src/main/java/org/inventivetalent/pluginannotations/command/AnnotatedCommand.java
+++ b/src/main/java/org/inventivetalent/pluginannotations/command/AnnotatedCommand.java
@@ -380,7 +380,7 @@ public class AnnotatedCommand {
 	private CommandMap getCommandMap() {
 		if (commandMap == null) {
 			try {
-				commandMap = (CommandMap) AccessUtil.setAccessible(Bukkit.getServer().getClass().getDeclaredField("commandMap")).get(Bukkit.getServer());
+				commandMap = (CommandMap) AccessUtil.setAccessible(Bukkit.getServer().getClass().getDeclaredField("commandMap"), true).get(Bukkit.getServer());
 			} catch (Exception e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
Since we only need to read that field, then attempting to remove final
modifier without a good reason only causes harm (like since Java 15
`Field#modifiers` field being hidden from most of the reflection API calls)